### PR TITLE
Refactoring...

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -19,7 +19,7 @@ func (b *Buffer) AppendByte(data byte) {
 }
 
 // AppendInt to buffer
-func (b *Buffer) AppendInt(val int, width int) {
+func (b *Buffer) AppendInt(remaining int, width int) {
 	var repr [8]byte
 	reprCount := len(repr) - 1
 	for remaining >= 10 || width > 1 {

--- a/buffer.go
+++ b/buffer.go
@@ -22,14 +22,14 @@ func (b *Buffer) AppendByte(data byte) {
 func (b *Buffer) AppendInt(val int, width int) {
 	var repr [8]byte
 	reprCount := len(repr) - 1
-	for val >= 10 || width > 1 {
+	for remaining >= 10 || width > 1 {
 		reminder := val / 10
-		repr[reprCount] = byte('0' + val - reminder*10)
-		val = reminder
+		repr[reprCount] = byte('0' + remaining - reminder*10)
+		remaining = reminder
 		reprCount--
 		width--
 	}
-	repr[reprCount] = byte('0' + val)
+	repr[reprCount] = byte('0' + remaining)
 	b.Append(repr[reprCount:])
 }
 

--- a/colorful.go
+++ b/colorful.go
@@ -7,7 +7,7 @@ type ColorBuffer struct {
 
 // color pallete map
 var (
-	colorOff    = []byte("\033[0m")
+	colorReset  = []byte("\033[0m")
 	colorRed    = []byte("\033[0;31m")
 	colorGreen  = []byte("\033[0;32m")
 	colorOrange = []byte("\033[0;33m")
@@ -18,8 +18,8 @@ var (
 )
 
 // Off apply no color to the data
-func (cb *ColorBuffer) Off() {
-	cb.Append(colorOff)
+func (cb *ColorBuffer) Reset() {
+	cb.Append(colorReset)
 }
 
 // Red apply red color to the data
@@ -60,7 +60,7 @@ func (cb *ColorBuffer) Gray() {
 // mixer mix the color on and off byte with the actual data
 func mixer(data []byte, color []byte) []byte {
 	var result []byte
-	return append(append(append(result, color...), data...), colorOff...)
+	return append(append(append(result, color...), data...), colorReset...)
 }
 
 // Red apply red color to the data

--- a/log.go
+++ b/log.go
@@ -241,7 +241,7 @@ func (l *Logger) output(prefix Prefix, data string) error {
 		l.buf.AppendByte(' ')
 		// Print reset color if color enabled
 		if l.color {
-			l.buf.Off()
+			l.buf.Reset()
 		}
 	}
 	// Add caller filename and line if enabled
@@ -259,7 +259,7 @@ func (l *Logger) output(prefix Prefix, data string) error {
 		l.buf.AppendByte(' ')
 		// Print color stop
 		if l.color {
-			l.buf.Off()
+			l.buf.Reset()
 		}
 	}
 	// Print the actual string data from caller
@@ -291,7 +291,7 @@ func (l *Logger) output(prefix Prefix, data string) error {
 			l.buf.AppendByte('\n')
 			// Print color stop
 			if l.color {
-				l.buf.Off()
+				l.buf.Reset()
 			}
 		}
 	}


### PR DESCRIPTION
I changed some variable names (not all because, idk.) and refactored the "Off" color to "Reset" because `\x1b[0m` is defined as *reset* by the ANSI Color Codes definition.